### PR TITLE
Use Elf64_Rela for relocations.

### DIFF
--- a/main.c
+++ b/main.c
@@ -136,12 +136,14 @@ static void initsections(void) {
   text->hdr.sh_addralign = 4;
 
   textrel = newsection();
+  textrel->hdr.sh_name = elfstr(shstrtab, ".rela.text");
   textrel->hdr.sh_type = SHT_RELA;
   textrel->hdr.sh_info = text->idx;
   textrel->hdr.sh_link = symtab->idx;
   textrel->hdr.sh_entsize = sizeof(Elf64_Rela);
 
   datarel = newsection();
+  datarel->hdr.sh_name = elfstr(shstrtab, ".rela.data");
   datarel->hdr.sh_type = SHT_RELA;
   datarel->hdr.sh_info = data->idx;
   datarel->hdr.sh_link = symtab->idx;

--- a/minias.h
+++ b/minias.h
@@ -35,6 +35,7 @@ typedef struct {
   Symbol *sym;
   int type;
   int64_t offset;
+  int64_t addend;
 } Relocation;
 
 typedef enum {


### PR DESCRIPTION
I needed this to run hello world on my system (otherwise I get a segfault). I'm not sure exactly why Elf64_Rel worked for you but not for me, but since the spec says to always use explicit addends, this seems like the right thing to do.