### PR TITLE
Mark external symbols as global (fixes example test)

### DIFF
--- a/main.c
+++ b/main.c
@@ -929,6 +929,15 @@ fillsymtab(void)
     Symbol *sym;
     size_t i;
 
+    /* Mark unknown symbols as global. */
+    for (i = 0; i < symbols->cap; i++) {
+        if (!symbols->keys[i].str)
+            continue;
+        sym = symbols->vals[i];
+        if (!sym->section)
+            sym->bind = STB_GLOBAL;
+    }
+
     /* Local symbols come first. */
     for (i = 0; i < symbols->cap; i++) {
         if (!symbols->keys[i].str)


### PR DESCRIPTION
I tried to assemble and run the "hello.s" test.

```
$ ./minias -o hello.o test/execute/0001-hello.s
$ clang hello.o -static -fuse-ld=lld
ld.lld: error: undefined symbol: puts
>>> referenced by hello.o:(.text+0xC)
>>> did you mean: fputs
>>> defined in: /lib/x86_64-linux-gnu/libc.a(iofputs.o)
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

If I link using the default GNU ld instead of LLD it silently resolves the call target to 0, which causes a segfault when it runs.

I believe this is caused by the `puts` symbols being marked as `STB_LOCAL` instead of `STB_GLOBAL`, so I have made a small patch to fix that.