### PR TITLE
Updates for QBE 1.2

### DIFF
--- a/asm.peg
+++ b/asm.peg
@@ -142,6 +142,8 @@ instr =
   | i:ucomisd { $$ = i; }
   | i:ucomiss { $$ = i; }
   | i:nop     { $$ = i; }
+  | i:endbr32 { $$ = i; }
+  | i:endbr64 { $$ = i; }
 
 call = "call" 'q'? ws (
     '*' t:mem
@@ -200,6 +202,9 @@ cqto =  "cqto"  { $$ = OP(0x01004899); }
 leave = "leave" { $$ = OP(0xc9); }
 nop =   "nop"   { $$ = OP(0x90); }
 ret  =  "ret"   { $$ = OP(0xc3); }
+
+endbr64 = "endbr64" { $$ = OP(0xF30F1EFA); }
+endbr32 = "endbr32" { $$ = OP(0xF30F1EFB); }
 
 push = "push" (
     'q'? ws  s:r64 { $$ = R({.w=0}, -1, 0x50, s); }

--- a/asm.peg
+++ b/asm.peg
@@ -41,6 +41,10 @@ directive =
     { $$ = fd; }
   | sd:section-directive
     { $$ = sd; }
+  | type-directive
+    { $$.kind = ASM_DIR_TYPE; }
+  | size-directive
+    { $$.kind = ASM_DIR_SIZE; }
 
 fill-directive = 
   "fill" ws r:number ws? "," ws? s:number ws? "," ws? v:number
@@ -61,6 +65,9 @@ section-flags = '"' <[awx]*> '"' { $$.charptr = internstring(yytext); }
 section-type =
     "@nobits" { $$.i64 = SHT_NOBITS; }
   | "@progbits" { $$.i64 = SHT_PROGBITS; }
+
+type-directive = "type" ws ident "," ws "@function"
+size-directive = "size" ws ident "," ws ".-" ident
 
 label = 
   i:ident ':'

--- a/main.c
+++ b/main.c
@@ -810,6 +810,10 @@ assemble(void)
             sym = getsym(v->set.sym);
             sym->value = v->set.value;
             break;
+        case ASM_DIR_TYPE:
+            break;
+        case ASM_DIR_SIZE:
+            break;
         case ASM_LABEL:
             sym = getsym(v->label.name);
             if (sym->defined)

--- a/main.c
+++ b/main.c
@@ -918,6 +918,10 @@ addtosymtab(Symbol *sym)
 
     sym->idx = symtab->hdr.sh_size / symtab->hdr.sh_entsize;
 
+    if (!sym->section) {
+        sym->bind = STB_GLOBAL;
+    }
+
     elfsym.st_name = elfstr(strtab, sym->name);
     elfsym.st_value = sym->value.c;
     elfsym.st_size = sym->size;

--- a/minias.h
+++ b/minias.h
@@ -68,6 +68,8 @@ typedef enum {
     ASM_DIR_INT,
     ASM_DIR_QUAD,
     ASM_DIR_BALIGN,
+    ASM_DIR_TYPE,
+    ASM_DIR_SIZE,
     // Instructions.
     ASM_JMP,
     ASM_INSTR,


### PR DESCRIPTION
* Handle endbr32 / endbr64 instructions from QBE.
* Type and size directives
* Set undefined symbols to global bind